### PR TITLE
Extend 1404 test artifact

### DIFF
--- a/contracts/test-artifacts/TestERC1404.sol
+++ b/contracts/test-artifacts/TestERC1404.sol
@@ -4,20 +4,22 @@ pragma solidity ^0.5.0;
 contract TestERC1404
 {
   uint8 public restriction;
+  mapping(address => bool) public alwaysApproved;
 
   function detectTransferRestriction(
     address _from,
-    address _to, 
-    uint256 _value
+    address _to,
+    uint256 //_value
   ) public view
     returns(uint8)
   {
+    if(alwaysApproved[_from] || alwaysApproved[_to]) return 0;
     return restriction;
   }
 
   function messageForTransferRestriction(
     uint8 _restrictionCode
-  ) public view 
+  ) public pure
     returns(string memory)
   {
     if(_restrictionCode == 0)
@@ -36,5 +38,12 @@ contract TestERC1404
   ) public
   {
     restriction = _restriction;
+  }
+
+  function approve(
+    address _alwaysApprovedAccount
+  ) public
+  {
+    alwaysApproved[_alwaysApprovedAccount] = true;
   }
 }


### PR DESCRIPTION
To support the pay use case which falls back to beneficiary when an account is not authorized.