### PR TITLE
+authorizeTransfer

### DIFF
--- a/contracts/ERC1404.vy
+++ b/contracts/ERC1404.vy
@@ -14,7 +14,7 @@ def initialize():
 
   self.owner = msg.sender
   self.approved[ZERO_ADDRESS] = True
-  
+
 @public
 @constant
 def detectTransferRestriction(

--- a/contracts/ERC1404.vy
+++ b/contracts/ERC1404.vy
@@ -14,8 +14,9 @@ def initialize():
 
   self.owner = msg.sender
   self.approved[ZERO_ADDRESS] = True
-
+  
 @public
+@constant
 def detectTransferRestriction(
   _from: address,
   _to: address,
@@ -25,6 +26,14 @@ def detectTransferRestriction(
     return 0
 
   return 1 # Denied
+
+@public
+def authorizeTransfer(
+  _from: address,
+  _to: address,
+  _value: uint256
+):
+  assert self.detectTransferRestriction(_from, _to, _value) == 0, "DENIED"
 
 @public
 @constant

--- a/contracts/FAIR.vy
+++ b/contracts/FAIR.vy
@@ -342,17 +342,18 @@ def _burn(
   self.balanceOf[_from] -= _amount
   self.totalSupply -= _amount
 
-  if(not (
+  if(
     (_operator == self.datAddress and _operatorData == SELL_FLAG)
     or
-    (_from == self.datAddress and _userData == SELL_FLAG))
+    (_from == self.datAddress and _userData == SELL_FLAG)
   ):
-    # This is a burn (vs a sell)
+    # This is a sell
+    self.authorizeTransfer(_from, ZERO_ADDRESS, _amount)
+  else:
+    # This is a burn
     assert self.dat.state() == STATE_RUN, "ONLY_DURING_RUN"
 
     self.burnedSupply += _amount
-  else:
-    self.authorizeTransfer(_from, ZERO_ADDRESS, _amount)
 
   log.Burned(_operator, _from, _amount, _userData, _operatorData)
   log.Transfer(_from, ZERO_ADDRESS, _amount)

--- a/test/wiki/burn/run.js
+++ b/test/wiki/burn/run.js
@@ -105,6 +105,12 @@ contract("wiki / burn / run", accounts => {
   });
 
   describe("If trades are restricted", () => {
+    beforeEach(async () => {
+      await contracts.erc1404.approve(accounts[5], false, {
+        from: await contracts.dat.control()
+      });
+    });
+
     it("Can burn even if account is restricted", async () => {
       await contracts.fair.burn(burnAmount, [], {
         from: investor

--- a/test/wiki/burn/run.js
+++ b/test/wiki/burn/run.js
@@ -106,7 +106,7 @@ contract("wiki / burn / run", accounts => {
 
   describe("If trades are restricted", () => {
     beforeEach(async () => {
-      await contracts.erc1404.approve(accounts[5], false, {
+      await contracts.erc1404.approve(investor, false, {
         from: await contracts.dat.control()
       });
     });

--- a/test/wiki/sell/run.js
+++ b/test/wiki/sell/run.js
@@ -179,4 +179,20 @@ contract("wiki / sell / run", accounts => {
       from: investor
     });
   });
+  
+  describe("If investor is not authorized, then the function exits.", () => {
+    beforeEach(async () => {
+      await contracts.erc1404.approve(accounts[5], false, {
+        from: await contracts.dat.control()
+      });
+    });
+
+    it("Sell fails", async () => {
+      await shouldFail(
+        await contracts.dat.sell(investor, sellAmount, "1", {
+          from: investor
+        })
+      );
+    });
+  });
 });

--- a/test/wiki/sell/run.js
+++ b/test/wiki/sell/run.js
@@ -179,17 +179,17 @@ contract("wiki / sell / run", accounts => {
       from: investor
     });
   });
-  
+
   describe("If investor is not authorized, then the function exits.", () => {
     beforeEach(async () => {
-      await contracts.erc1404.approve(accounts[5], false, {
+      await contracts.erc1404.approve(investor, false, {
         from: await contracts.dat.control()
       });
     });
 
     it("Sell fails", async () => {
       await shouldFail(
-        await contracts.dat.sell(investor, sellAmount, "1", {
+        contracts.dat.sell(investor, sellAmount, "1", {
           from: investor
         })
       );


### PR DESCRIPTION
Adding a non-constant authorizeTransfer and switching to use that in FAIR.  This allows the ERC1404 contract to save some information on transfer (or buy/sell), enabling new use cases.

Additionally while reviewing this I see the authorization on sell was missed.