### PR TITLE
Fix estimateSellValue overflow

### DIFF
--- a/c-org-abi/package.json
+++ b/c-org-abi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairmint/c-org-abi",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "ABI for c-org contracts including FAIR and DAT.",
   "repository": {
     "type": "git",

--- a/contracts/DecentralizedAutonomousTrust.sol
+++ b/contracts/DecentralizedAutonomousTrust.sol
@@ -853,11 +853,19 @@ contract DecentralizedAutonomousTrust
       // Math: worst case
       // MAX * MAX * MAX_BEFORE_SQUARE
       // / MAX_BEFORE_SQUARE/2 * MAX_BEFORE_SQUARE/2
-      currencyValue -= BigDiv.bigDiv2x1RoundUp(
+      temp = BigDiv.bigDiv2x1RoundUp(
         _quantityToSell.mul(_quantityToSell),
         reserve,
         supply * supply
       );
+      if(currencyValue > temp)
+      {
+        currencyValue -= temp;
+      }
+      else
+      {
+        currencyValue = 0;
+      }
     }
     else if(state == STATE_CLOSE)
     {

--- a/test/dat/sellSmallValue.js
+++ b/test/dat/sellSmallValue.js
@@ -1,0 +1,57 @@
+const { approveAll, deployDat } = require("../helpers");
+const { reverts } = require("truffle-assertions");
+const { assert } = require("chai");
+
+/*
+Testing the following scenario, which was a bug in version <= 2:
+  state == RUN
+  reserve == 15672691058
+  totalSupply == 317046271116763072800229
+  burnedSupply == 0
+  quantityToSell == 1
+  estimatedSellValue == 0 (was MAX_UINT)
+ */
+contract("dat / sellSmallValue", (accounts) => {
+  let contracts;
+
+  before(async () => {
+    contracts = await deployDat(accounts, {
+      initReserve: "317046271116763072800229",
+      buySlopeNum: "1",
+      buySlopeDen: "100000000000000000000000",
+    });
+    await approveAll(contracts, accounts);
+
+    // Transfer ETH to set the correct buybackReserve
+    await web3.eth.sendTransaction({
+      to: contracts.dat.address,
+      value: "15672691058",
+      from: accounts[0],
+    });
+  });
+
+  it("is in the correct state", async () => {
+    const actual = await contracts.dat.state();
+    assert.equal(actual.toString(), "1");
+  });
+
+  it("has correct reserve", async () => {
+    const actual = await contracts.dat.buybackReserve();
+    assert.equal(actual.toString(), "15672691058");
+  });
+
+  it("has correct totalSupply", async () => {
+    const actual = await contracts.dat.totalSupply();
+    assert.equal(actual.toString(), "317046271116763072800229");
+  });
+
+  it("has correct burnedSupply", async () => {
+    const actual = await contracts.dat.burnedSupply();
+    assert.equal(actual.toString(), "0");
+  });
+
+  it("estimateSellValue is correct", async () => {
+    const actual = await contracts.dat.estimateSellValue("1");
+    assert.equal(actual.toString(), "0");
+  });
+});

--- a/test/whitelist/authorizeTransfer.js
+++ b/test/whitelist/authorizeTransfer.js
@@ -128,7 +128,7 @@ contract("dat / whitelist / authorizeTransfer", (accounts) => {
 
     it("cannot sell", async () => {
       await reverts(
-        contracts.dat.sell(trader, 1, 1, {
+        contracts.dat.sell(trader, "100000000", 1, {
           from: trader,
         }),
         "DENIED: JURISDICTION_FLOW"

--- a/test/wiki/sell/run.js
+++ b/test/wiki/sell/run.js
@@ -62,7 +62,7 @@ contract("wiki / sell / run", (accounts) => {
     await contracts.dat.transfer(investor, sellAmount, { from: beneficiary });
     await reverts(
       contracts.dat.sell(investor, sellAmount, 1, { from: investor }),
-      "Address: insufficient balance" // from the currency (buyback reserve)
+      "PRICE_SLIPPAGE"
     );
   });
 


### PR DESCRIPTION
This bug (applicable to versions <= 2) should not pose any financial risk. When encountered, the value is so high that it would be impossible for the contract to honor that value on sell. So this only results in a potential messaging problem.