### PR TITLE
Add halt/resume functions for Whitelist

### DIFF
--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -553,7 +553,6 @@ contract Whitelist is IWhitelist, Ownable, OperatorRole {
     }
   }
 
-  
   function _isJurisdictionHalted(uint _jurisdictionId) internal view returns(bool){
     uint until = jurisdictionHaltsUntil[_jurisdictionId];
     return until != 0 && until > now;

--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -18,6 +18,7 @@ contract Whitelist is IWhitelist, Ownable, OperatorRole {
   uint8 private constant STATUS_ERROR_JURISDICTION_FLOW = 1;
   uint8 private constant STATUS_ERROR_LOCKUP = 2;
   uint8 private constant STATUS_ERROR_USER_UNKNOWN = 3;
+  uint8 private constant STATUS_ERROR_JURISDICTION_HALT = 4;
 
   event ConfigWhitelist(
     uint _startDate,
@@ -140,10 +141,6 @@ contract Whitelist is IWhitelist, Ownable, OperatorRole {
    */
   mapping(address => mapping(uint => Lockup)) internal userIdLockups;
 
- 
-  // error code to be returnd on detectTransferRestriction
-  // returned when from/to jurisdictionId is in halted state
-  uint8 private constant STATUS_ERROR_JURISDICTION_HALT = 4;
   /**
    * @notice Maps Jurisdiction Id to it's halt due
    */

--- a/test/whitelist/halt.js
+++ b/test/whitelist/halt.js
@@ -1,8 +1,13 @@
 const { deployDat } = require("../datHelpers");
 const { approveAll } = require("../helpers");
-const { constants, BN, expectRevert, expectEvent, time } = require("@openzeppelin/test-helpers");
+const {
+  constants,
+  BN,
+  expectRevert,
+  expectEvent,
+  time,
+} = require("@openzeppelin/test-helpers");
 
-const { BigNumber } = require("bignumber.js");
 const { assert } = require("chai");
 
 contract("whitelist / halt", (accounts) => {
@@ -10,55 +15,68 @@ contract("whitelist / halt", (accounts) => {
   let ownerAccount;
 
   const operatorAccount = accounts[1];
-  const haltedApproved = accounts[7]
-  const resumedApproved = accounts[8]
-  const resumeApproved_2 = accounts[9];
+  const haltedApproved = accounts[7];
+  const resumedApproved = accounts[8];
   const haltedJurisdiction = 2;
-  const resumedJurisdiction = 4;
   beforeEach(async () => {
     contracts = await deployDat(accounts);
     ownerAccount = await contracts.whitelist.owner();
     await approveAll(contracts, accounts);
     await contracts.whitelist.updateJurisdictionFlows(
-        [1, 2, 2],
-        [2, 1, 2],
-        [1, 1, 1],
-        {
-          from: ownerAccount,
-        }
-      );
-    await contracts.whitelist.updateJurisdictionFlows(
-        [2, 4],
-        [4, 2],
-        [1, 1],
-        {
-          from: ownerAccount,
-        }
-      )
-    await contracts.whitelist.updateJurisdictionsForUserIds([haltedApproved], [haltedJurisdiction],{from:operatorAccount});
+      [1, 2, 2],
+      [2, 1, 2],
+      [1, 1, 1],
+      {
+        from: ownerAccount,
+      }
+    );
+    await contracts.whitelist.updateJurisdictionFlows([2, 4], [4, 2], [1, 1], {
+      from: ownerAccount,
+    });
+    await contracts.whitelist.updateJurisdictionsForUserIds(
+      [haltedApproved],
+      [haltedJurisdiction],
+      { from: operatorAccount }
+    );
   });
 
   it("non-operators cannot halt", async () => {
     const due = (await time.latest()).add(time.duration.weeks(1));
-    await expectRevert(contracts.whitelist.halt([haltedJurisdiction],[due], {from:accounts[9]}), "Ownable: caller is not the owner");
+    await expectRevert(
+      contracts.whitelist.halt([haltedJurisdiction], [due], {
+        from: accounts[9],
+      }),
+      "Ownable: caller is not the owner"
+    );
   });
 
   it("operators can addApprovedUserWallets", async () => {
     const due = (await time.latest()).add(time.duration.weeks(1));
-    await contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount});
+    await contracts.whitelist.halt([haltedJurisdiction], [due], {
+      from: ownerAccount,
+    });
   });
 
   it("shouldFail to halt if expirationTimestamp is not future", async () => {
     const due = (await time.latest()).sub(time.duration.weeks(1));
-    await expectRevert(contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount}), "HALT_DUE_SHOULD_BE_FUTURE");
+    await expectRevert(
+      contracts.whitelist.halt([haltedJurisdiction], [due], {
+        from: ownerAccount,
+      }),
+      "HALT_DUE_SHOULD_BE_FUTURE"
+    );
   });
 
   it("should emit Halt event", async () => {
     const due = (await time.latest()).add(time.duration.weeks(1));
-    const receipt = await contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount});
+    const receipt = await contracts.whitelist.halt(
+      [haltedJurisdiction],
+      [due],
+      { from: ownerAccount }
+    );
     expectEvent.inLogs(receipt.logs, "Halt", {
       _jurisdictionId: new BN(haltedJurisdiction),
-      _until:due
+      _until: due,
     });
   });
 
@@ -75,64 +93,103 @@ contract("whitelist / halt", (accounts) => {
       });
 
       const due = (await time.latest()).add(time.duration.weeks(1));
-      await contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount});
+      await contracts.whitelist.halt([haltedJurisdiction], [due], {
+        from: ownerAccount,
+      });
     });
 
     it("should change jurisdictionHaltsUntil value", async () => {
-      const until = await contracts.whitelist.jurisdictionHaltsUntil(haltedJurisdiction);
-      assert.notEqual(
-        new BN(until),
-        new BN(0)
+      const until = await contracts.whitelist.jurisdictionHaltsUntil(
+        haltedJurisdiction
       );
+      assert.notEqual(new BN(until), new BN(0));
     });
 
     it("shouldFail to transfer when sender's jurisdiction is halted", async () => {
-      await expectRevert(contracts.dat.transfer(resumedApproved, 100, {from:haltedApproved}),"FROM_JURISDICTION_HALTED");
-      const error_code = await contracts.whitelist.detectTransferRestriction(haltedApproved, resumedApproved, 100);
-      assert.equal(error_code,4);
-    });
-    
-    it("shouldFail to transfer when reciever's jurisdiction is halted", async () => {
-      await expectRevert(contracts.dat.transfer(haltedApproved, 100, {from:resumedApproved}),"TO_JURISDICTION_HALTED");
-      const error_code = await contracts.whitelist.detectTransferRestriction(resumedApproved, haltedApproved, 100);
-      assert.equal(error_code,4);
-    });
-    
-    it("shouldFail to buy when buyer's jurisdiction is halted", async () => {
-      const price = web3.utils.toWei("100", "ether");
-      await expectRevert(contracts.dat.buy(haltedApproved, price, 1, {from:haltedApproved, value:price}),"TO_JURISDICTION_HALTED");
-      const error_code = await contracts.whitelist.detectTransferRestriction(constants.ZERO_ADDRESS, haltedApproved, 100);
-      assert.equal(error_code,4);
-    });
-    
-    it("shouldFail to sell when seller's jurisdiction is halted", async () => {
-      await expectRevert(contracts.dat.sell(haltedApproved, 100, 1, {from:haltedApproved}),"FROM_JURISDICTION_HALTED");
-      const error_code = await contracts.whitelist.detectTransferRestriction(haltedApproved, constants.ZERO_ADDRESS, 100);
-      assert.equal(error_code,4);
+      await expectRevert(
+        contracts.dat.transfer(resumedApproved, 100, { from: haltedApproved }),
+        "FROM_JURISDICTION_HALTED"
+      );
+      const error_code = await contracts.whitelist.detectTransferRestriction(
+        haltedApproved,
+        resumedApproved,
+        100
+      );
+      assert.equal(error_code, 4);
     });
 
-    describe('when halt ended', ()=>{
-      beforeEach(async ()=>{
+    it("shouldFail to transfer when reciever's jurisdiction is halted", async () => {
+      await expectRevert(
+        contracts.dat.transfer(haltedApproved, 100, { from: resumedApproved }),
+        "TO_JURISDICTION_HALTED"
+      );
+      const error_code = await contracts.whitelist.detectTransferRestriction(
+        resumedApproved,
+        haltedApproved,
+        100
+      );
+      assert.equal(error_code, 4);
+    });
+
+    it("shouldFail to buy when buyer's jurisdiction is halted", async () => {
+      const price = web3.utils.toWei("100", "ether");
+      await expectRevert(
+        contracts.dat.buy(haltedApproved, price, 1, {
+          from: haltedApproved,
+          value: price,
+        }),
+        "TO_JURISDICTION_HALTED"
+      );
+      const error_code = await contracts.whitelist.detectTransferRestriction(
+        constants.ZERO_ADDRESS,
+        haltedApproved,
+        100
+      );
+      assert.equal(error_code, 4);
+    });
+
+    it("shouldFail to sell when seller's jurisdiction is halted", async () => {
+      await expectRevert(
+        contracts.dat.sell(haltedApproved, 100, 1, { from: haltedApproved }),
+        "FROM_JURISDICTION_HALTED"
+      );
+      const error_code = await contracts.whitelist.detectTransferRestriction(
+        haltedApproved,
+        constants.ZERO_ADDRESS,
+        100
+      );
+      assert.equal(error_code, 4);
+    });
+
+    describe("when halt ended", () => {
+      beforeEach(async () => {
         await time.increase(time.duration.weeks(2));
       });
       it("should success to transfer when sender's jurisdiction halt ended", async () => {
-        await contracts.dat.transfer(resumedApproved, 100, {from:haltedApproved});
+        await contracts.dat.transfer(resumedApproved, 100, {
+          from: haltedApproved,
+        });
       });
 
       it("should success to transfer when reciever's jurisdiction halt ended", async () => {
-        await contracts.dat.transfer(haltedApproved, 100, {from:resumedApproved});
+        await contracts.dat.transfer(haltedApproved, 100, {
+          from: resumedApproved,
+        });
       });
 
       it("should success to buy when buyer's jurisdiction halt ended", async () => {
         const price = web3.utils.toWei("100", "ether");
-        await contracts.dat.buy(haltedApproved, price, 1, {from:haltedApproved, value:price});
+        await contracts.dat.buy(haltedApproved, price, 1, {
+          from: haltedApproved,
+          value: price,
+        });
       });
 
       it("should success to sell when seller's jurisdiction halt ended", async () => {
-        await contracts.dat.sell(haltedApproved, 100, 1, {from:haltedApproved});
+        await contracts.dat.sell(haltedApproved, 100, 1, {
+          from: haltedApproved,
+        });
       });
-
     });
   });
 });
-

--- a/test/whitelist/halt.js
+++ b/test/whitelist/halt.js
@@ -1,0 +1,138 @@
+const { deployDat } = require("../datHelpers");
+const { approveAll } = require("../helpers");
+const { constants, BN, expectRevert, expectEvent, time } = require("@openzeppelin/test-helpers");
+
+const { BigNumber } = require("bignumber.js");
+const { assert } = require("chai");
+
+contract("whitelist / halt", (accounts) => {
+  let contracts;
+  let ownerAccount;
+
+  const operatorAccount = accounts[1];
+  const haltedApproved = accounts[7]
+  const resumedApproved = accounts[8]
+  const resumeApproved_2 = accounts[9];
+  const haltedJurisdiction = 2;
+  const resumedJurisdiction = 4;
+  beforeEach(async () => {
+    contracts = await deployDat(accounts);
+    ownerAccount = await contracts.whitelist.owner();
+    await approveAll(contracts, accounts);
+    await contracts.whitelist.updateJurisdictionFlows(
+        [1, 2, 2],
+        [2, 1, 2],
+        [1, 1, 1],
+        {
+          from: ownerAccount,
+        }
+      );
+    await contracts.whitelist.updateJurisdictionFlows(
+        [2, 4],
+        [4, 2],
+        [1, 1],
+        {
+          from: ownerAccount,
+        }
+      )
+    await contracts.whitelist.updateJurisdictionsForUserIds([haltedApproved], [haltedJurisdiction],{from:operatorAccount});
+  });
+
+  it("non-operators cannot halt", async () => {
+    const due = (await time.latest()).add(time.duration.weeks(1));
+    await expectRevert(contracts.whitelist.halt([haltedJurisdiction],[due], {from:accounts[9]}), "Ownable: caller is not the owner");
+  });
+
+  it("operators can addApprovedUserWallets", async () => {
+    const due = (await time.latest()).add(time.duration.weeks(1));
+    await contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount});
+  });
+
+  it("shouldFail to halt if expirationTimestamp is not future", async () => {
+    const due = (await time.latest()).sub(time.duration.weeks(1));
+    await expectRevert(contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount}), "HALT_DUE_SHOULD_BE_FUTURE");
+  });
+
+  it("should emit Halt event", async () => {
+    const due = (await time.latest()).add(time.duration.weeks(1));
+    const receipt = await contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount});
+    expectEvent.inLogs(receipt.logs, "Halt", {
+      _jurisdictionId: new BN(haltedJurisdiction),
+      _until:due
+    });
+  });
+
+  describe("after halt", () => {
+    beforeEach(async () => {
+      const price = web3.utils.toWei("100", "ether");
+      await contracts.dat.buy(haltedApproved, price, 1, {
+        from: haltedApproved,
+        value: price,
+      });
+      await contracts.dat.buy(resumedApproved, price, 1, {
+        from: resumedApproved,
+        value: price,
+      });
+
+      const due = (await time.latest()).add(time.duration.weeks(1));
+      await contracts.whitelist.halt([haltedJurisdiction],[due], {from:ownerAccount});
+    });
+
+    it("should change jurisdictionHaltsUntil value", async () => {
+      const until = await contracts.whitelist.jurisdictionHaltsUntil(haltedJurisdiction);
+      assert.notEqual(
+        new BN(until),
+        new BN(0)
+      );
+    });
+
+    it("shouldFail to transfer when sender's jurisdiction is halted", async () => {
+      await expectRevert(contracts.dat.transfer(resumedApproved, 100, {from:haltedApproved}),"FROM_JURISDICTION_HALTED");
+      const error_code = await contracts.whitelist.detectTransferRestriction(haltedApproved, resumedApproved, 100);
+      assert.equal(error_code,4);
+    });
+    
+    it("shouldFail to transfer when reciever's jurisdiction is halted", async () => {
+      await expectRevert(contracts.dat.transfer(haltedApproved, 100, {from:resumedApproved}),"TO_JURISDICTION_HALTED");
+      const error_code = await contracts.whitelist.detectTransferRestriction(resumedApproved, haltedApproved, 100);
+      assert.equal(error_code,4);
+    });
+    
+    it("shouldFail to buy when buyer's jurisdiction is halted", async () => {
+      const price = web3.utils.toWei("100", "ether");
+      await expectRevert(contracts.dat.buy(haltedApproved, price, 1, {from:haltedApproved, value:price}),"TO_JURISDICTION_HALTED");
+      const error_code = await contracts.whitelist.detectTransferRestriction(constants.ZERO_ADDRESS, haltedApproved, 100);
+      assert.equal(error_code,4);
+    });
+    
+    it("shouldFail to sell when seller's jurisdiction is halted", async () => {
+      await expectRevert(contracts.dat.sell(haltedApproved, 100, 1, {from:haltedApproved}),"FROM_JURISDICTION_HALTED");
+      const error_code = await contracts.whitelist.detectTransferRestriction(haltedApproved, constants.ZERO_ADDRESS, 100);
+      assert.equal(error_code,4);
+    });
+
+    describe('when halt ended', ()=>{
+      beforeEach(async ()=>{
+        await time.increase(time.duration.weeks(2));
+      });
+      it("should success to transfer when sender's jurisdiction halt ended", async () => {
+        await contracts.dat.transfer(resumedApproved, 100, {from:haltedApproved});
+      });
+
+      it("should success to transfer when reciever's jurisdiction halt ended", async () => {
+        await contracts.dat.transfer(haltedApproved, 100, {from:resumedApproved});
+      });
+
+      it("should success to buy when buyer's jurisdiction halt ended", async () => {
+        const price = web3.utils.toWei("100", "ether");
+        await contracts.dat.buy(haltedApproved, price, 1, {from:haltedApproved, value:price});
+      });
+
+      it("should success to sell when seller's jurisdiction halt ended", async () => {
+        await contracts.dat.sell(haltedApproved, 100, 1, {from:haltedApproved});
+      });
+
+    });
+  });
+});
+

--- a/test/whitelist/resume.js
+++ b/test/whitelist/resume.js
@@ -1,8 +1,12 @@
 const { deployDat } = require("../datHelpers");
 const { approveAll } = require("../helpers");
-const { BN, expectRevert, expectEvent, time } = require("@openzeppelin/test-helpers");
+const {
+  BN,
+  expectRevert,
+  expectEvent,
+  time,
+} = require("@openzeppelin/test-helpers");
 
-const { BigNumber } = require("bignumber.js");
 const { assert } = require("chai");
 
 contract("whitelist / resume", (accounts) => {
@@ -10,9 +14,8 @@ contract("whitelist / resume", (accounts) => {
   let ownerAccount;
 
   const operatorAccount = accounts[1];
-  const haltedApproved = accounts[7]
-  const resumedApproved = accounts[8]
-  const resumeApproved_2 = accounts[9];
+  const haltedApproved = accounts[7];
+  const resumedApproved = accounts[8];
   const haltedJurisdiction = 2;
   const resumedJurisdiction = 4;
   beforeEach(async () => {
@@ -20,84 +23,104 @@ contract("whitelist / resume", (accounts) => {
     ownerAccount = await contracts.whitelist.owner();
     await approveAll(contracts, accounts);
     await contracts.whitelist.updateJurisdictionFlows(
-        [1, 2, 2],
-        [2, 1, 2],
-        [1, 1, 1],
-        {
-          from: ownerAccount,
-        }
-      );
-    await contracts.whitelist.updateJurisdictionFlows(
-        [2, 4],
-        [4, 2],
-        [1, 1],
-        {
-          from: ownerAccount,
-        }
-      )
-      await contracts.whitelist.updateJurisdictionsForUserIds([haltedApproved], [haltedJurisdiction],{from:operatorAccount});
-      const price = web3.utils.toWei("100", "ether");
-      await contracts.dat.buy(haltedApproved, price, 1, {
-        from: haltedApproved,
-        value: price,
-      });
-      await contracts.dat.buy(resumedApproved, price, 1, {
-        from: resumedApproved,
-        value: price,
-      });
+      [1, 2, 2],
+      [2, 1, 2],
+      [1, 1, 1],
+      {
+        from: ownerAccount,
+      }
+    );
+    await contracts.whitelist.updateJurisdictionFlows([2, 4], [4, 2], [1, 1], {
+      from: ownerAccount,
+    });
+    await contracts.whitelist.updateJurisdictionsForUserIds(
+      [haltedApproved],
+      [haltedJurisdiction],
+      { from: operatorAccount }
+    );
+    const price = web3.utils.toWei("100", "ether");
+    await contracts.dat.buy(haltedApproved, price, 1, {
+      from: haltedApproved,
+      value: price,
+    });
+    await contracts.dat.buy(resumedApproved, price, 1, {
+      from: resumedApproved,
+      value: price,
+    });
 
-      const due = (await time.latest()).add(time.duration.weeks(1));
-      await contracts.whitelist.halt([haltedJurisdiction], [due], {from:ownerAccount});
+    const due = (await time.latest()).add(time.duration.weeks(1));
+    await contracts.whitelist.halt([haltedJurisdiction], [due], {
+      from: ownerAccount,
+    });
   });
 
   it("non-operators cannot halt", async () => {
-    await expectRevert(contracts.whitelist.resume([haltedJurisdiction], {from:accounts[9]}), "Ownable: caller is not the owner");
+    await expectRevert(
+      contracts.whitelist.resume([haltedJurisdiction], { from: accounts[9] }),
+      "Ownable: caller is not the owner"
+    );
   });
 
   it("operators can addApprovedUserWallets", async () => {
-    await contracts.whitelist.resume([haltedJurisdiction], {from:ownerAccount});
+    await contracts.whitelist.resume([haltedJurisdiction], {
+      from: ownerAccount,
+    });
   });
 
-  it("shouldFail if the jurisdiction is not halted", async () =>{
-    await expectRevert(contracts.whitelist.resume([resumedJurisdiction], {from:ownerAccount}), "ATTEMPT_TO_RESUME_NONE_HALTED_JURISDICATION");
+  it("shouldFail if the jurisdiction is not halted", async () => {
+    await expectRevert(
+      contracts.whitelist.resume([resumedJurisdiction], { from: ownerAccount }),
+      "ATTEMPT_TO_RESUME_NONE_HALTED_JURISDICATION"
+    );
   });
 
   it("should emit Resume event", async () => {
-    const receipt = await contracts.whitelist.resume([haltedJurisdiction], {from:ownerAccount});
+    const receipt = await contracts.whitelist.resume([haltedJurisdiction], {
+      from: ownerAccount,
+    });
     expectEvent.inLogs(receipt.logs, "Resume", {
-      _jurisdictionId: new BN(haltedJurisdiction)
+      _jurisdictionId: new BN(haltedJurisdiction),
     });
   });
 
   describe("after resume", () => {
     beforeEach(async () => {
-      await contracts.whitelist.resume([haltedJurisdiction], {from:ownerAccount});
+      await contracts.whitelist.resume([haltedJurisdiction], {
+        from: ownerAccount,
+      });
     });
 
     it("should change jurisdictionHaltsUntil value to zero", async () => {
-      const until = await contracts.whitelist.jurisdictionHaltsUntil(haltedJurisdiction);
-      assert.equal(
-        new BN(until).toString(),
-        new BN(0).toString()
+      const until = await contracts.whitelist.jurisdictionHaltsUntil(
+        haltedJurisdiction
       );
+      assert.equal(new BN(until).toString(), new BN(0).toString());
     });
 
     it("should be able to transfer when sender's jurisdiction is resumed", async () => {
-      await contracts.dat.transfer(resumedApproved, 100, {from:haltedApproved});
+      await contracts.dat.transfer(resumedApproved, 100, {
+        from: haltedApproved,
+      });
     });
-    
+
     it("should be able to transfer when reciever's jurisdiction is resumed", async () => {
-      await contracts.dat.transfer(haltedApproved, 100, {from:resumedApproved});
+      await contracts.dat.transfer(haltedApproved, 100, {
+        from: resumedApproved,
+      });
     });
-    
+
     it("should be able to buy when buyer's jurisdiction is resumed", async () => {
       const price = web3.utils.toWei("100", "ether");
-      await contracts.dat.buy(haltedApproved, price, 1, {from:haltedApproved, value:price});
+      await contracts.dat.buy(haltedApproved, price, 1, {
+        from: haltedApproved,
+        value: price,
+      });
     });
-    
+
     it("should be able to sell when seller's jurisdiction is resumed", async () => {
-      await contracts.dat.sell(haltedApproved, 100, 1, {from:haltedApproved});
+      await contracts.dat.sell(haltedApproved, 100, 1, {
+        from: haltedApproved,
+      });
     });
   });
 });
-

--- a/test/whitelist/resume.js
+++ b/test/whitelist/resume.js
@@ -1,0 +1,103 @@
+const { deployDat } = require("../datHelpers");
+const { approveAll } = require("../helpers");
+const { BN, expectRevert, expectEvent, time } = require("@openzeppelin/test-helpers");
+
+const { BigNumber } = require("bignumber.js");
+const { assert } = require("chai");
+
+contract("whitelist / resume", (accounts) => {
+  let contracts;
+  let ownerAccount;
+
+  const operatorAccount = accounts[1];
+  const haltedApproved = accounts[7]
+  const resumedApproved = accounts[8]
+  const resumeApproved_2 = accounts[9];
+  const haltedJurisdiction = 2;
+  const resumedJurisdiction = 4;
+  beforeEach(async () => {
+    contracts = await deployDat(accounts);
+    ownerAccount = await contracts.whitelist.owner();
+    await approveAll(contracts, accounts);
+    await contracts.whitelist.updateJurisdictionFlows(
+        [1, 2, 2],
+        [2, 1, 2],
+        [1, 1, 1],
+        {
+          from: ownerAccount,
+        }
+      );
+    await contracts.whitelist.updateJurisdictionFlows(
+        [2, 4],
+        [4, 2],
+        [1, 1],
+        {
+          from: ownerAccount,
+        }
+      )
+      await contracts.whitelist.updateJurisdictionsForUserIds([haltedApproved], [haltedJurisdiction],{from:operatorAccount});
+      const price = web3.utils.toWei("100", "ether");
+      await contracts.dat.buy(haltedApproved, price, 1, {
+        from: haltedApproved,
+        value: price,
+      });
+      await contracts.dat.buy(resumedApproved, price, 1, {
+        from: resumedApproved,
+        value: price,
+      });
+
+      const due = (await time.latest()).add(time.duration.weeks(1));
+      await contracts.whitelist.halt([haltedJurisdiction], [due], {from:ownerAccount});
+  });
+
+  it("non-operators cannot halt", async () => {
+    await expectRevert(contracts.whitelist.resume([haltedJurisdiction], {from:accounts[9]}), "Ownable: caller is not the owner");
+  });
+
+  it("operators can addApprovedUserWallets", async () => {
+    await contracts.whitelist.resume([haltedJurisdiction], {from:ownerAccount});
+  });
+
+  it("shouldFail if the jurisdiction is not halted", async () =>{
+    await expectRevert(contracts.whitelist.resume([resumedJurisdiction], {from:ownerAccount}), "ATTEMPT_TO_RESUME_NONE_HALTED_JURISDICATION");
+  });
+
+  it("should emit Resume event", async () => {
+    const receipt = await contracts.whitelist.resume([haltedJurisdiction], {from:ownerAccount});
+    expectEvent.inLogs(receipt.logs, "Resume", {
+      _jurisdictionId: new BN(haltedJurisdiction)
+    });
+  });
+
+  describe("after resume", () => {
+    beforeEach(async () => {
+      await contracts.whitelist.resume([haltedJurisdiction], {from:ownerAccount});
+    });
+
+    it("should change jurisdictionHaltsUntil value to zero", async () => {
+      const until = await contracts.whitelist.jurisdictionHaltsUntil(haltedJurisdiction);
+      assert.equal(
+        new BN(until).toString(),
+        new BN(0).toString()
+      );
+    });
+
+    it("should be able to transfer when sender's jurisdiction is resumed", async () => {
+      await contracts.dat.transfer(resumedApproved, 100, {from:haltedApproved});
+    });
+    
+    it("should be able to transfer when reciever's jurisdiction is resumed", async () => {
+      await contracts.dat.transfer(haltedApproved, 100, {from:resumedApproved});
+    });
+    
+    it("should be able to buy when buyer's jurisdiction is resumed", async () => {
+      const price = web3.utils.toWei("100", "ether");
+      await contracts.dat.buy(haltedApproved, price, 1, {from:haltedApproved, value:price});
+    });
+    
+    it("should be able to sell when seller's jurisdiction is resumed", async () => {
+      await contracts.dat.sell(haltedApproved, 100, 1, {from:haltedApproved});
+    });
+  });
+});
+


### PR DESCRIPTION
## Added

### variable
- STATUS_ERROR_JURISDICTION_HALT : erc-1404 error code
- jurisdictionHaltsUntil: maps jurisdiction id to halt due(unix timestmap)

### event
- Halt : emitted when jurisdiction is halted
- Resume : emitted when jurisdiction is resumed

### function
- halt() : halts jurisdicition
- resume() : resumes jurisdiction

## Updated

- detectTransferRestriction() : now returns STATUS_ERROR_JURISDICTION_HALT when `from` or `to` belongs to halted jurisdiction
- authorizeTransfer() : now throws when `from` or `to` belongs to halted jurisdiction
affects ContinuousOffering#{transfer(),buy(),sell()}